### PR TITLE
Doc improvements

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,12 +177,10 @@ node {
 
         slackMessageJson = JsonOutput.prettyPrint(asset_json_file_content)
 
-        if (isDevelopment) {
-          // sends to #notifications
-          slackSend(channel: '#notifications', message: '```' + slackMessageJson + '```')
-        } else {
+        if (!isDevelopment) {
           // sends to #backend
-          slackSend(channel: '#backend', message: '```' + slackMessageJson + '```')
+          slackSend(
+            channel: '#backend', message: '```' + slackMessageJson + '```\n:warning: New asseets are NOT automatically used\n`v1/config`must be adapted to reference the new assets\nSee https://github.com/i-mobility/assets#releasing for more info')
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -180,7 +180,7 @@ node {
         if (!isDevelopment) {
           // sends to #backend
           slackSend(
-            channel: '#backend', message: '```' + slackMessageJson + '```\n:warning: New asseets are NOT automatically used\n`v1/config`must be adapted to reference the new assets\nSee https://github.com/i-mobility/assets#releasing for more info')
+            channel: '#backend', message: '```' + slackMessageJson + '```\n\n:warning: New assets are NOT automatically used\n`v1/config`must be adapted to reference the new assets\nSee https://github.com/i-mobility/assets#releasing for more info')
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ the jenkins pipeline which will create a release for you.
 
 
 > [!IMPORTANT]
-> Creating a release does not automatically serve the new assets
-> `v1/config` endpoint has to be adapted to reference this newly created release 
-> See [here](https://github.com/i-mobility/backend/commit/08aa89a4eaeb2b77d20ca11901e80ec5509caec8) for a example 
+> Creating a release does not automatically serve the new assets.
+>
+> `v1/config` endpoint must to be adapted to reference the newly created release.
+> See [here](https://github.com/i-mobility/backend/commit/08aa89a4eaeb2b77d20ca11901e80ec5509caec8) for a example.

--- a/README.md
+++ b/README.md
@@ -22,3 +22,8 @@ from the root directory before pushing new images.
 Just merge development branch to master branch - this will invoke 
 the jenkins pipeline which will create a release for you.
 
+
+> [!IMPORTANT]
+> Creating a release does not automatically serve the new assets
+> `v1/config` endpoint has to be adapted to reference this newly created release 
+> See [here](https://github.com/i-mobility/backend/commit/08aa89a4eaeb2b77d20ca11901e80ec5509caec8) for a example 


### PR DESCRIPTION
I often get asked why assets are not being used by Clients and then remind them that `v1/config` has to be updated to reference the newly created release.

Hopefully reduces this a bit by just always including the disclaimer and adding it to the README :) 