### PR TITLE
[IMOB-13107] Replace transportation_group.public_transport with transportation_group.public

### DIFF
--- a/definitions.json
+++ b/definitions.json
@@ -1173,7 +1173,7 @@
   "transportation_group": [
     {
       "id": "public",
-      "translation_key": "transportation_group.public_transport"
+      "translation_key": "transportation_group.public"
     },
     {
       "id": "walk",


### PR DESCRIPTION
This fixes builds for android developers. They currently crash because the key does not exist.